### PR TITLE
Remove ArgoCD deploy step

### DIFF
--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -22,18 +22,3 @@ jobs:
     secrets:
       cypher_client_id: ${{ secrets.CYPHER_CLIENT_ID }}
       cypher_client_secret: ${{ secrets.CYPHER_CLIENT_SECRET }}
-
-  deploy-to-k8s:
-    permissions:
-      id-token: write
-    if: startsWith(github.ref, 'refs/tags/')
-    needs:
-      - docker-build
-    uses: ethdevops/workflows/.github/workflows/deploy-via-argocd.yaml@main
-    with:
-      team: security
-      project: website
-    secrets:
-      cypher_client_id: ${{ secrets.CYPHER_CLIENT_ID }}
-      cypher_client_secret: ${{ secrets.CYPHER_CLIENT_SECRET }}
-


### PR DESCRIPTION
updating is handled on the backend side now automatically for all new semver tags that will pop up on the docker registry. 