### PR TITLE
ci: build via OpenBao OIDC instead of Infisical

### DIFF
--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -1,4 +1,3 @@
-# .github/workflows/main.yml
 name: Build and Deploy
 on:
   push:
@@ -6,19 +5,15 @@ on:
     branches: ["master"]
 
 permissions:
-  contents: write
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
+  contents: read
+
 jobs:
   docker-build:
     permissions:
+      contents: read
       packages: write
       id-token: write
-      contents: read
-    uses: ethdevops/workflows/.github/workflows/basic-docker-build-cypher.yaml@main
-    secrets:
-      cypher_client_id: ${{ secrets.CYPHER_CLIENT_ID }}
-      cypher_client_secret: ${{ secrets.CYPHER_CLIENT_SECRET }}
+    uses: EthDevOps/workflows/.github/workflows/basic-docker-build-openbao.yaml@main
+    with:
+      bao_role: protocol-security-website-ci
+      bao_secret_path: secret/protocol-security/data/website/production/docker


### PR DESCRIPTION
Fixes broken workflow as it currently fetches registry credentials from Infisical, a secret store no longer in use. This switches to a reusable workflow that authenticates to OpenBao with the repository's GitHub OIDC token. Note that the `CYPHER_CLIENT_ID` and `CYPHER_CLIENT_SECRET` repo secrets can be removed after merging this PR. After merging you can create a new tag to trigger another workflow.