### PR TITLE
Serve a proper production build instead of the Vite dev server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ out
 
 # Production
 build
+dist
 
 # Misc
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,27 @@
-FROM node:alpine
+# syntax=docker/dockerfile:1
 
-# Set working directory
+# --- Build stage: compile the static production bundle ---
+FROM node:alpine AS build
+
 WORKDIR /app
 
-# Copy package files
+# Install dependencies (leverage layer caching)
 COPY package.json package-lock.json* ./
-
-# Install dependencies
 RUN npm ci
 
-# Copy source files
+# Copy source and build the optimized production bundle into /app/dist
 COPY . .
+RUN npm run build
 
-# Expose the port the app runs on
+# --- Runtime stage: serve the static bundle with nginx ---
+FROM nginx:alpine AS runtime
+
+# SPA-aware nginx config (client-side routing fallback to index.html)
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy the built assets from the build stage
+COPY --from=build /app/dist /usr/share/nginx/html
+
 EXPOSE 3000
 
-# Start npm dev server
-CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "3000"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,30 @@
+server {
+    listen 3000;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip static assets
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+
+    # Cache hashed, immutable build assets aggressively
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # SPA fallback: let react-router handle client-side routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Never cache the HTML entry point so new deploys are picked up
+    location = /index.html {
+        expires -1;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+}


### PR DESCRIPTION
## Summary

The container image was running the **Vite dev server** as production (`npm run dev`), which ships unminified assets, runs a dev-only server not intended for production traffic, and carries HMR overhead. This switches to a proper production build.

## Changes

- **`Dockerfile`** — now a multi-stage build:
  - **build stage** (`node:alpine`): `npm ci` + `npm run build` → optimized/minified static bundle
  - **runtime stage** (`nginx:alpine`): serves the static bundle, still listens on port `3000`; no Node/dev-server in the final image (smaller, production-grade)
- **`nginx.conf`** (new):
  - SPA fallback (`try_files … /index.html`) so react-router client routes work on direct navigation/refresh
  - hashed `/assets/*` cached `1y immutable`; `index.html` never cached so new deploys are picked up immediately
  - gzip enabled
- **`.dockerignore`** — added `dist` so a stale local build can't leak into the build context.

The deploy workflow (`basic-docker-build-openbao.yaml`) just builds and pushes the repo's `Dockerfile`, so no workflow changes are needed — the production build is fully driven by the Dockerfile.

## Verification

Built and ran the image locally:

| Check | Result |
|---|---|
| `docker build` | ✅ builds, minified bundle emitted |
| `GET /` | ✅ `200 text/html` |
| Deep client route | ✅ `200` (SPA fallback) |
| `/assets/*.js` | ✅ `public, immutable, max-age=31536000` |
| `/index.html` | ✅ `no-cache, no-store, must-revalidate` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)